### PR TITLE
vmm: Fix clippy wanrnings

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -854,20 +854,20 @@ impl Vm {
 
         cfg_if::cfg_if! {
             if #[cfg(feature = "tdx")] {
+                let mut tdx_opt = 0; // SEV_SNP_DISABLED
+                if tdx_enabled {
+                    tdx_opt = 1; // KVM_X86_TDX_VM
+                }
                 let vm = hypervisor
-                    .create_vm_with_type(if tdx_enabled {
-                        1 // KVM_X86_TDX_VM
-                    } else {
-                        0 // KVM_X86_LEGACY_VM
-                    })
+                    .create_vm_with_type(tdx_opt)
                     .unwrap();
             } else if #[cfg(feature = "sev_snp")] {
+                let mut snp_opt = 0; // SEV_SNP_DISABLED
+                if sev_snp_enabled {
+                    snp_opt = 1; // SEV_SNP_ENABLED
+                }
                 let vm = hypervisor
-                    .create_vm_with_type(if sev_snp_enabled {
-                        1 // SEV_SNP_ENABLED
-                    } else {
-                        0 // SEV_SNP_DISABLED
-                    })
+                    .create_vm_with_type(snp_opt)
                     .unwrap();
             } else {
                 let vm = hypervisor.create_vm().unwrap();


### PR DESCRIPTION
This patch fizes following warnings:
error: boolean to int conversion using if
   --> vmm/src/vm.rs:866:42
    |
866 |                       .create_vm_with_type(if sev_snp_enabled.into() {
    |  __________________________________________^
867 | |                         1 // SEV_SNP_ENABLED
868 | |                     } else {
869 | |                         0 // SEV_SNP_DISABLED
870 | |                     })
    | |_____________________^ help: replace with from: `u64::from(sev_snp_enabled.into())`
    |
    = note: `-D clippy::bool-to-int-with-if` implied by `-D warnings`
    = note: `sev_snp_enabled.into() as u64` or `sev_snp_enabled.into().into()` can also be valid options
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if

error: useless conversion to the same type: `bool`
   --> vmm/src/vm.rs:866:45
    |
866 |                     .create_vm_with_type(if sev_snp_enabled.into() {
    |                                             ^^^^^^^^^^^^^^^^^^^^^^ help: consider removing `.into()`: `sev_snp_enabled`
    |
    = note: `-D clippy::useless-conversion` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion

error: could not compile `vmm` due to 2 previous errors